### PR TITLE
Improve seeding logging

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -251,13 +251,14 @@ class ServerlessDynamoDBPlugin implements Plugin {
     if (this.shouldExecute()) {
       const dynamodb = this.dynamodbOptions();
 
-      await Promise.all(this.seedSources.flatMap(async (source) => {
+      await Promise.all(this.seedSources.map(async (source) => {
         if (!source.table) {
           throw new Error('seeding source "table" property not defined');
         }
         const seedPromise = writeSeeds((params) => dynamodb.doc.send(new BatchWriteCommand(params)), source.table, locateSeeds(source.sources || []));
         const rawSeedPromise = writeSeeds((params) => dynamodb.raw.send(new BatchWriteItemCommand(params)), source.table, locateSeeds(source.rawsources || []));
-        return [seedPromise, rawSeedPromise];
+        await Promise.all([seedPromise, rawSeedPromise]);
+        console.log(`Seed running complete for table: ${source.table}`);
       }));
       return;
     }

--- a/src/seeder.ts
+++ b/src/seeder.ts
@@ -66,8 +66,7 @@ export async function writeSeeds(dynamodbWriteFunction: DynamoDBWriteFunction, t
   }
 
   const seedChunks = chunk(seedValues, MAX_MIGRATION_CHUNK);
-  await Promise.all(seedChunks.map((chunk) => writeSeedBatch(dynamodbWriteFunction, tableName, chunk)))
-    .then(() => console.log(`Seed running complete for table: ${tableName}`));
+  await Promise.all(seedChunks.map((chunk) => writeSeedBatch(dynamodbWriteFunction, tableName, chunk)));
 }
 
 const chunk = <T>(input: T[], size: number): T[][] => {


### PR DESCRIPTION
This avoids logging twice for each table, and avoids misleading logs that suggest seeding is complete for a table when it is not.