### PR TITLE
Fix dbPath isAbsolute logic

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -275,7 +275,7 @@ class ServerlessDynamoDBPlugin implements Plugin {
         ...this.options,
       };
 
-      if (options.dbPath && path.isAbsolute(options.dbPath)) {
+      if (options.dbPath && !path.isAbsolute(options.dbPath)) {
         options.dbPath = path.join(this.serverless.config.servicePath, options.dbPath);
       }
 


### PR DESCRIPTION
This logic seems to have been inverted in the typescript rewrite.
At least using an absolute path no longer worked.

Old logic: https://github.com/raisenational/serverless-dynamodb/blob/10a908caeba64cfdfd0e14eda5f639e101e558aa/index.js#L270

As an aside, I haven't been able to make dbPath work with docker at all, but maybe that's unsupported?