### PR TITLE
Improve BillingMode replacement

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -384,7 +384,7 @@ class ServerlessDynamoDBPlugin implements Plugin {
     if (command['Tags']) {
       delete command['Tags'];
     }
-    if (command['BillingMode'] === 'PAY_PER_REQUEST') {
+    if (command['BillingMode'] !== 'PROVISIONED') {
       delete command['BillingMode'];
 
       const defaultProvisioning = {


### PR DESCRIPTION
Background:
We have a conditional billing mode on prod vs staging environments.
```
Conditions:
    IsProd:
        Fn::Equals:
            - ${self:provider.stage}
            - prod
```
and the billing mode:
```
            BillingMode: !If
                - IsProd
                - PROVISIONED
                - PAY_PER_REQUEST
```

This PR supports these kind of configurations